### PR TITLE
feature_rebuild_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alchemate implements and abstracts high-level functionality to SOMD2 FEP engine,
 Using alchemate involves creating a SOMD2 configuration object, defining a simulation workflow, and creating a manager which will run the specified workflows sequentially:
 
 ```python
-from somd2.config import Config as somd2_config
+from somd2.config import Config
 from alchemate.manager import WorkflowManager
 from alchemate.context import SimulationContext
 
@@ -23,7 +23,7 @@ from alchemate.steps.base import RunBasicCalculation
 from alchemate.steps.postprocessing import OptimizeConvergence
 
 # Define SOMD2 configuration for setting up the physical simultion (electrostatics, cutoff, timestep, etc.)
-somd2_config = somd2_config()
+somd2_config = Config()
 somd2_config.cutoff_type = "RF"
 somd2_config.cutoff = "12A"
 somd2_config.replica_exchange = True

--- a/examples/run_full_workflow.py
+++ b/examples/run_full_workflow.py
@@ -1,4 +1,4 @@
-from somd2.config import Config as somd2_config
+from somd2.config import Config
 from alchemate.manager import WorkflowManager
 from alchemate.context import SimulationContext
 from alchemate.steps.base import RunBasicCalculation
@@ -7,7 +7,7 @@ from alchemate.logger import setup_logging
 
 setup_logging()
 
-somd2_config = somd2_config()
+somd2_config = Config()
 somd2_config.cutoff_type = "RF"
 somd2_config.cutoff = "12A"
 somd2_config.runtime = "100ps"

--- a/examples/run_simple_workflow.py
+++ b/examples/run_simple_workflow.py
@@ -1,10 +1,10 @@
-from somd2.config import Config as somd2_config
+from somd2.config import Config
 from alchemate.manager import WorkflowManager
 from alchemate.context import SimulationContext
 from alchemate.steps.preprocessing import OptimizeExchangeProbabilities
 from alchemate.logger import setup_logging
 
-somd2_config = somd2_config()
+somd2_config = Config()
 somd2_config.cutoff_type = "RF"
 somd2_config.cutoff = "12A"
 somd2_config.num_lambda = 4
@@ -16,7 +16,7 @@ context = SimulationContext(system="merged_molecule.s3", somd2_config=somd2_conf
 setup_logging(log_path=f"{context.somd2_config.output_directory}/alchemate.log")
 
 simulation_workflow = [
-    OptimizeExchangeProbabilities(optimization_runtime="100ps"),
+    OptimizeExchangeProbabilities(optimization_runtime="500ps"),
 ]
 
 manager = WorkflowManager(context=context, workflow_steps=simulation_workflow)

--- a/src/alchemate/context.py
+++ b/src/alchemate/context.py
@@ -22,7 +22,7 @@
 import logging
 import pickle
 from types import SimpleNamespace
-from somd2.config import Config as _somd2_config
+from somd2.config import Config
 
 _logger = logging.getLogger("alchemate.logger")
 
@@ -35,7 +35,7 @@ class SimulationContext:
     ----------
     system : Any
         The system object associated with the simulation.
-    somd2_config : Somd2Config
+    somd2_config : Config
         Configuration object for the simulation, validated on initialization.
     results : types.SimpleNamespace
         Namespace for dynamically storing results and intermediate data.
@@ -68,9 +68,9 @@ class SimulationContext:
         self._initialized = False
 
         # Perform input validation
-        if not isinstance(somd2_config, type(_somd2_config())):
+        if not isinstance(somd2_config, type(Config())):
             raise TypeError(
-                f"Expected somd2_config to be an instance of {_somd2_config}, got {type(somd2_config)}"
+                f"Expected somd2_config to be an instance of {Config}, got {type(somd2_config)}"
             )
 
         # Define mutable attributes

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,11 +1,14 @@
 import pytest
-from somd2.config import Config as somd2_config
+import tempfile
+import sire as sr
+import somd2
+from somd2.config import Config
 from alchemate.context import SimulationContext
 
 
 @pytest.fixture
 def mock_context(tmp_path):
-    context = SimulationContext(system="mock_system", somd2_config=somd2_config())
+    context = SimulationContext(system="mock_system", somd2_config=Config())
     context.somd2_config.cutoff = "14A"
     context.somd2_config.num_lambda = 21
     context.somd2_config.output_directory = tmp_path
@@ -20,7 +23,7 @@ def test_immutable_properties(mock_context):
         mock_context.foo = "bar"
 
 
-def test_saving_and_loading(tmp_path, mock_context):
+def test_pickle_saving_and_loading(tmp_path, mock_context):
     mock_context.save()
     loaded_context = SimulationContext.load(f"{tmp_path}/alchemate_context.pkl")
 
@@ -33,3 +36,20 @@ def test_saving_and_loading(tmp_path, mock_context):
         loaded_context.somd2_config.output_directory
         == mock_context.somd2_config.output_directory
     )
+
+
+def test_rebuilding_from_previous_somd2_output(tmp_path):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a SOMD2 output directory to mimick a previously ran simulation
+        merged_mols = sr.load(sr.expand(sr.tutorial_url, "merged_molecule.s3"))
+        config = Config(platform="cpu", output_directory=tmpdir, cutoff="14A")
+        _ = somd2.runner.Runner(merged_mols, config)
+
+        # Now test the alchemate SimulationContext can be rebuilt from the SOMD2 output
+        somd2_config = Config().from_yaml(f"{tmpdir}/config.yaml")
+
+        context = SimulationContext(
+            system="merged_molecule.s3", somd2_config=somd2_config
+        )
+
+        assert context.somd2_config.cutoff == "14A"


### PR DESCRIPTION
Closes #3 by adding an example to the test suite showing how to build a `SimulationContext` from previously ran SOMD2 simulations. Turns out this functionality was already implicitly implemented as SOMD2 `Config` object can be reconstructed from `yaml` files or by individually rebuilding it if it contains tags that cannot be rebuilt from `yaml`. This means in theory we should be able to apply processing workflows with SOMD2 simulations ran outside of alchemate.