### PR TITLE
Use spawn start method for processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 Modular [SOMD2](https://github.com/OpenBioSim/somd2) processing workflows.
 
 ## Purpose
+
 Alchemate implements and abstracts high-level functionality to SOMD2 FEP engine, such as iterative λ-schedule optimization or convergence detection for example. The framework is designed to be modular and extensible which allows for arbitrary workflows to be written and plugged in easily.
 
 ## Usage
+
 Using alchemate involves creating a SOMD2 configuration object, defining a simulation workflow, and creating a manager which will run the specified workflows sequentially:
 
 ```python
@@ -41,7 +43,8 @@ simulation_workflow = [
 manager = WorkflowManager(context=context, workflow_steps=simulation_workflow)
 
 # Run everything, manager will keep track of workflow steps that are completed
-final_context = manager.execute()
+if __name_ == "__main__":
+  final_context = manager.execute()
 ```
 
 At the heart of alchemate is the `SimulationContext` class which gets passed through workflows sequentially and updated with new information. This can for example, be used to attempt and pre-optimize the λ-schedule of a transformation in vacuum, before using the updated context in the main simulation:
@@ -63,6 +66,7 @@ simulation_workflow = [
 ```
 
 In general, workflows are divided into 3 different categories based on the data that the context is supposed to hold at that point:
+
 1. **Pre-processing:**
     - Simulation data is not expected.
     - Workflows here perform actions to augment the base workflow.
@@ -75,10 +79,13 @@ In general, workflows are divided into 3 different categories based on the data 
 
 Head to [examples](examples/) for more detailed scripts.
 ___
+
 ## Installation
 
 ### General use
+
 To install alchemate, please install [SOMD2](https://github.com/OpenBioSim/somd2) into your conda environment first. Then you can install alchemate into your environment by cloning this repository, and running:
+
 ```bash
 pip install -e .
 ```
@@ -86,16 +93,19 @@ pip install -e .
 ### Developing and contributing
 
 Developer dependencies can be installed with:
+
 ```bash
 pip install -e '.[dev]'
 ```
 
 and activating commit hooks:
+
 ```bash
 pre-commit install
 ```
 
 Testing is done using:
+
 ```bash
 python -m pytest -svvv --color=yes tests
 ```

--- a/src/alchemate/context.py
+++ b/src/alchemate/context.py
@@ -77,7 +77,9 @@ class SimulationContext:
         self.system = system
         self.somd2_config = somd2_config
         self.base_directory = somd2_config.output_directory
-        self.results = SimpleNamespace()  # to allow dynamic attribute assignment, i.e. self.results.new_attribute = value
+        self.results = (
+            SimpleNamespace()
+        )  # to allow dynamic attribute assignment, i.e. self.results.new_attribute = value
         self.completed_steps = set()  # to track completed workflow steps
 
         # Lock the instance to prevent further modifications outside mutable properties

--- a/src/alchemate/steps/_run_somd2.py
+++ b/src/alchemate/steps/_run_somd2.py
@@ -49,14 +49,14 @@ def _run_somd2_workflow(context: SimulationContext, max_restarts: int = 5):
         The function utilizes multiprocessing to run the SOMD2 workflow in an isolated process.
     """
 
-    result_queue = multiprocessing.Queue()
+    ctx = multiprocessing.get_context("spawn")
+
+    result_queue = ctx.Queue()
 
     _logger.debug(f"Provided somd2_config: {context.somd2_config}")
 
     # Create a process object for the SOMD2 workflow
-    process = multiprocessing.Process(
-        target=_run_somd2_process, args=(context, result_queue)
-    )
+    process = ctx.Process(target=_run_somd2_process, args=(context, result_queue))
     process.start()
 
     _logger.debug(f"Process started with PID: {process.pid}")
@@ -79,7 +79,7 @@ def _run_somd2_workflow(context: SimulationContext, max_restarts: int = 5):
 
             context.somd2_config.restart = True
 
-            process = multiprocessing.Process(
+            process = ctx.Process(
                 target=_run_somd2_process, args=(context, result_queue)
             )
             process.start()

--- a/tests/test_run_somd2.py
+++ b/tests/test_run_somd2.py
@@ -14,19 +14,19 @@ class TestRunSomd2Workflow:
         context.somd2_config.restart = False
         return context
 
-    @patch("alchemate.steps._run_somd2.multiprocessing.Process")
-    @patch("alchemate.steps._run_somd2.multiprocessing.Queue")
-    def test_successful_execution_first_attempt(
-        self, mock_queue_class, mock_process_class, mock_context
-    ):
+    @patch("alchemate.steps._run_somd2.multiprocessing.get_context")
+    def test_successful_execution_first_attempt(self, mock_get_context, mock_context):
         # Setup
+        mock_ctx = Mock()
+        mock_get_context.return_value = mock_ctx
+
         mock_queue = Mock()
         mock_queue.get.return_value = {"success": True}
-        mock_queue_class.return_value = mock_queue
+        mock_ctx.Queue.return_value = mock_queue
 
         mock_process = Mock()
         mock_process.pid = 12345
-        mock_process_class.return_value = mock_process
+        mock_ctx.Process.return_value = mock_process
 
         # Execute
         _run_somd2_workflow(mock_context)
@@ -36,23 +36,24 @@ class TestRunSomd2Workflow:
         mock_process.join.assert_called_once()
         mock_queue.get.assert_called_once_with(timeout=10)
         assert mock_context.somd2_config.restart is False
+        mock_get_context.assert_called_with("spawn")
 
-    @patch("alchemate.steps._run_somd2.multiprocessing.Process")
-    @patch("alchemate.steps._run_somd2.multiprocessing.Queue")
-    def test_restart_after_error(
-        self, mock_queue_class, mock_process_class, mock_context
-    ):
+    @patch("alchemate.steps._run_somd2.multiprocessing.get_context")
+    def test_restart_after_error(self, mock_get_context, mock_context):
         # Setup
+        mock_ctx = Mock()
+        mock_get_context.return_value = mock_ctx
+
         mock_queue = Mock()
         mock_queue.get.side_effect = [
             {"error": "Test error"},  # First hard attempt fails
             {"success": True},  # Second hard attempt succeeds
         ]
-        mock_queue_class.return_value = mock_queue
+        mock_ctx.Queue.return_value = mock_queue
 
         mock_process = Mock()
         mock_process.pid = 12345
-        mock_process_class.return_value = mock_process
+        mock_ctx.Process.return_value = mock_process
 
         # Execute
         _run_somd2_workflow(mock_context, max_restarts=1)
@@ -60,63 +61,69 @@ class TestRunSomd2Workflow:
         # Assert
         assert mock_process.start.call_count == 2
         assert mock_process.join.call_count == 2
+        mock_get_context.assert_called_with("spawn")
 
-    @patch("alchemate.steps._run_somd2.multiprocessing.Process")
-    @patch("alchemate.steps._run_somd2.multiprocessing.Queue")
+    @patch("alchemate.steps._run_somd2.multiprocessing.get_context")
     def test_all_attempts_fail_raises_runtime_error(
-        self, mock_queue_class, mock_process_class, mock_context
+        self, mock_get_context, mock_context
     ):
         # Setup
+        mock_ctx = Mock()
+        mock_get_context.return_value = mock_ctx
+
         mock_queue = Mock()
         mock_queue.get.return_value = {"error": "Persistent error"}
-        mock_queue_class.return_value = mock_queue
+        mock_ctx.Queue.return_value = mock_queue
 
         mock_process = Mock()
         mock_process.pid = 12345
-        mock_process_class.return_value = mock_process
+        mock_ctx.Process.return_value = mock_process
 
         # Execute & Assert
         with pytest.raises(
             RuntimeError, match="SOMD2 workflow failed after multiple attempts"
         ):
             _run_somd2_workflow(mock_context, max_restarts=1)
+        mock_get_context.assert_called_with("spawn")
 
-    @patch("alchemate.steps._run_somd2.multiprocessing.Process")
-    @patch("alchemate.steps._run_somd2.multiprocessing.Queue")
-    def test_queue_timeout_handling(
-        self, mock_queue_class, mock_process_class, mock_context
-    ):
+    @patch("alchemate.steps._run_somd2.multiprocessing.get_context")
+    def test_queue_timeout_handling(self, mock_get_context, mock_context):
         # Setup
+        mock_ctx = Mock()
+        mock_get_context.return_value = mock_ctx
+
         mock_queue = Mock()
         mock_queue.get.side_effect = [
             {"error": "Test error"},  # Hard attempt fails
             Empty(),  # Soft restart times out
             {"success": True},  # Next soft restart succeeds
         ]
-        mock_queue_class.return_value = mock_queue
+        mock_ctx.Queue.return_value = mock_queue
 
         mock_process = Mock()
         mock_process.pid = 12345
-        mock_process_class.return_value = mock_process
+        mock_ctx.Process.return_value = mock_process
 
         # Execute
         _run_somd2_workflow(mock_context, max_restarts=3)
 
         # Assert
         assert mock_process.start.call_count == 3
+        mock_get_context.assert_called_with("spawn")
 
-    @patch("alchemate.steps._run_somd2.multiprocessing.Process")
-    @patch("alchemate.steps._run_somd2.multiprocessing.Queue")
-    def test_custom_restart_limits(
-        self, mock_queue_class, mock_process_class, mock_context
-    ):
+    @patch("alchemate.steps._run_somd2.multiprocessing.get_context")
+    def test_custom_restart_limits(self, mock_get_context, mock_context):
         # Setup
+        mock_ctx = Mock()
+        mock_get_context.return_value = mock_ctx
+
         mock_queue = Mock()
         mock_queue.get.return_value = {"error": "Test error"}
-        mock_queue_class.return_value = mock_queue
+        mock_ctx.Queue.return_value = mock_queue
 
         mock_process = Mock()
-        mock_process_class.return_value = mock_process
+        mock_process.pid = 12345
+        mock_ctx.Process.return_value = mock_process
 
         # Execute & Assert
         with pytest.raises(RuntimeError):
@@ -124,3 +131,4 @@ class TestRunSomd2Workflow:
 
         # Should have 3 attempts in total
         assert mock_process.start.call_count == 4
+        mock_get_context.assert_called_with("spawn")


### PR DESCRIPTION
This PR makes sure `somd2` worker processes are started using a context that was created with the spawn start method. This allows the worker process to access the GPU platform/context information, which would otherwise be blocked by the main process. This leads to the following error:

```
...

2026-01-28 16:17:57.716 | ERROR    | somd2.runner._repex:_check_device_memory:552 - Device index 0 out of range. Found 0 GPU(s).
Process Process-2:
Traceback (most recent call last):
  File "/home/lester/.conda/envs/openbiosim/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/lester/.conda/envs/openbiosim/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/lester/Code/openbiosim/alchemate/src/alchemate/steps/_run_somd2.py", line 131, in _run_somd2_process
    runner = somd2.runner.RepexRunner(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lester/Code/openbiosim/somd2/src/somd2/runner/_repex.py", line 715, in __init__
    self._dynamics_cache = DynamicsCache(
                           ^^^^^^^^^^^^^^
  File "/home/lester/Code/openbiosim/somd2/src/somd2/runner/_repex.py", line 114, in __init__
    self._create_dynamics(
  File "/home/lester/Code/openbiosim/somd2/src/somd2/runner/_repex.py", line 239, in _create_dynamics
    used_mem_before, free_mem_before, total_mem = self._check_device_memory(
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lester/Code/openbiosim/somd2/src/somd2/runner/_repex.py", line 553, in _check_device_memory
    raise IndexError(msg)
IndexError: Device index 0 out of range. Found 0 GPU(s).
ERROR:alchemate.logger:Error in step RunBasicCalculation:
ERROR:alchemate.logger:Workflow execution failed.
```

The use of...

```python
final_context = manager.execute()
if __name_ == "__main__":
  final_context = manager.execute()
```

...isn't strictly needed, you'll just see a warning if you don't do this. I'll see if there's a way to wrap things so that it's not necessary.

Apologies for the large diff in the README. It looks like my vim config has applied some formatting tweaks. I'm happy to revert this if desired. (I actually did exclude the edits from my initial commit, then accidentally used `-a` when adding later commits.)